### PR TITLE
removed Werror from CMakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,6 @@ target_compile_options(${PROJECT_NAME}
                                  -Wold-style-cast
                                  -Wshadow
                                  -Wweak-vtables
-                                 -Werror
                                  -Wall>
         $<$<C_COMPILER_ID:GNU>:-Waddress
                                -Waggregate-return
@@ -127,7 +126,6 @@ target_compile_options(${PROJECT_NAME}
                                -Wunreachable-code
                                -Wwrite-strings
                                -Wpointer-arith
-                               -Werror
                                -Wall>
        $<$<C_COMPILER_ID:MSVC>:/Wall>
 )


### PR DESCRIPTION
UnityFail and UnityIgnore because noreturn function does return

/github/workspace/wge/src/unity/src/unity.c: In function ‘UnityFail’:
/github/workspace/wge/src/unity/src/unity.c:1792:1: error: ‘noreturn’ function does return [-Werror]
 1792 | }
      | ^
/github/workspace/wge/src/unity/src/unity.c: In function ‘UnityIgnore’:
/github/workspace/wge/src/unity/src/unity.c:1808:1: error: ‘noreturn’ function does return [-Werror]
 1808 | }
      | ^